### PR TITLE
tag onlpv1-r5.0.4 from ufi-onlpv1-dev branch

### DIFF
--- a/packages/platforms/ufispace/x86-64/s9300-32d/platform-config/r0/src/lib/tech_support/show_platform_log.sh
+++ b/packages/platforms/ufispace/x86-64/s9300-32d/platform-config/r0/src/lib/tech_support/show_platform_log.sh
@@ -44,6 +44,11 @@ GPIO_OFFSET=0
 # CPLD max index
 MAX_CPLD=3
 
+# Execution Time
+start_time=$(date +%s)
+end_time=0
+elapsed_time=0
+
 # NETIF name, should be changed according NOS naming
 NET_IF=""
 
@@ -70,7 +75,7 @@ function _banner {
 }
 
 function _pkg_version {
-    _banner "Package Version = 1.0.0"
+    _banner "Package Version = 1.0.10"
 }
 
 function _update_gpio_offset {
@@ -1522,6 +1527,20 @@ function _additional_log_collection {
     fi
 }
 
+function _show_time {
+    _banner "Show Execution Time"
+    end_time=$(date +%s)
+    elapsed_time=$(( end_time - start_time ))
+    
+    ret=`date -d @${start_time}`
+    _echo "[Start Time ] ${ret}"
+    
+    ret=`date -d @${end_time}`
+    _echo "[End Time   ] ${ret}"    
+    
+    _echo "[Elapse Time] ${elapsed_time} seconds"
+}
+
 function _compression {
     _banner "Compression"
     
@@ -1574,6 +1593,7 @@ function _main {
     _show_bmc_sel_elist_detail
     _show_dmesg
     _additional_log_collection
+    _show_time    
     _compression
 
     echo "#   done..."

--- a/packages/platforms/ufispace/x86-64/s9301-32db/platform-config/r0/src/lib/tech_support/show_platform_log.sh
+++ b/packages/platforms/ufispace/x86-64/s9301-32db/platform-config/r0/src/lib/tech_support/show_platform_log.sh
@@ -45,6 +45,11 @@ GPIO_OFFSET=0
 # CPLD max index
 MAX_CPLD=3
 
+# Execution Time
+start_time=$(date +%s)
+end_time=0
+elapsed_time=0
+
 # NETIF name, should be changed according NOS naming
 NET_IF=""
 
@@ -71,7 +76,7 @@ function _banner {
 }
 
 function _pkg_version {
-    _banner "Package Version = 1.0.0"
+    _banner "Package Version = 1.0.5"
 }
 
 function _update_gpio_offset {
@@ -1662,6 +1667,20 @@ function _additional_log_collection {
     fi
 }
 
+function _show_time {
+    _banner "Show Execution Time"
+    end_time=$(date +%s)
+    elapsed_time=$(( end_time - start_time ))
+    
+    ret=`date -d @${start_time}`
+    _echo "[Start Time ] ${ret}"
+    
+    ret=`date -d @${end_time}`
+    _echo "[End Time   ] ${ret}"    
+    
+    _echo "[Elapse Time] ${elapsed_time} seconds"
+}
+
 function _compression {
     _banner "Compression"
     
@@ -1715,6 +1734,7 @@ function _main {
     _show_bmc_sel_elist_detail
     _show_dmesg
     _additional_log_collection
+    _show_time    
     _compression
 
     echo "#   done..."

--- a/packages/platforms/ufispace/x86-64/s9600-72xc/platform-config/r0/src/lib/tech_support/show_platform_log.sh
+++ b/packages/platforms/ufispace/x86-64/s9600-72xc/platform-config/r0/src/lib/tech_support/show_platform_log.sh
@@ -44,6 +44,11 @@ GPIO_OFFSET=0
 # CPLD max index
 MAX_CPLD=4
 
+# Execution Time
+start_time=$(date +%s)
+end_time=0
+elapsed_time=0
+
 function _echo {
     str="$@"
 
@@ -67,7 +72,7 @@ function _banner {
 }
 
 function _pkg_version {
-    _banner "Package Version = 1.0.1"
+    _banner "Package Version = 1.0.14"
 }
 
 function _update_gpio_offset {
@@ -1655,6 +1660,20 @@ function _additional_log_collection {
     fi
 }
 
+function _show_time {
+    _banner "Show Execution Time"
+    end_time=$(date +%s)
+    elapsed_time=$(( end_time - start_time ))
+    
+    ret=`date -d @${start_time}`
+    _echo "[Start Time ] ${ret}"
+    
+    ret=`date -d @${end_time}`
+    _echo "[End Time   ] ${ret}"    
+    
+    _echo "[Elapse Time] ${elapsed_time} seconds"
+}
+
 function _compression {
     _banner "Compression"
     
@@ -1709,6 +1728,7 @@ function _main {
     _show_bmc_sel_elist_detail
     _show_dmesg
     _additional_log_collection
+    _show_time
     _compression
 
     echo "#   done..."

--- a/packages/platforms/ufispace/x86-64/s9701-82dc/onlp/builds/x86_64_ufispace_s9701_82dc/module/src/sfpi.c
+++ b/packages/platforms/ufispace/x86-64/s9701-82dc/onlp/builds/x86_64_ufispace_s9701_82dc/module/src/sfpi.c
@@ -312,7 +312,7 @@ int qsfp_control_set(port_type_info_t port_info, onlp_sfp_control_t control, int
     //sysfs path
     switch(control) {
         case ONLP_SFP_CONTROL_RESET:
-            snprintf(sysfs, sizeof(sysfs), "%s/"MB_CPLD_QSFP_GROUP_PRES_ATTR_FMT,
+            snprintf(sysfs, sizeof(sysfs), "%s/"MB_CPLD_QSFP_GROUP_RESET_ATTR_FMT,
                 cpld_sysfs_path, qsfp_group_str[port_info.port_group]);
             //0 for reset, 1 for out of reset, reverse the value
             value = (value) ? 0:1;

--- a/packages/platforms/ufispace/x86-64/s9701-82dc/platform-config/r0/src/lib/tech_support/show_platform_log.sh
+++ b/packages/platforms/ufispace/x86-64/s9701-82dc/platform-config/r0/src/lib/tech_support/show_platform_log.sh
@@ -44,6 +44,11 @@ GPIO_OFFSET=0
 # CPLD max index
 MAX_CPLD=4
 
+# Execution Time
+start_time=$(date +%s)
+end_time=0
+elapsed_time=0
+
 function _echo {
     str="$@"
 
@@ -67,7 +72,7 @@ function _banner {
 }
 
 function _pkg_version {
-    _banner "Package Version = 1.0.1"
+    _banner "Package Version = 1.0.8"
 }
 
 function _update_gpio_offset {
@@ -1757,6 +1762,20 @@ function _additional_log_collection {
     fi
 }
 
+function _show_time {
+    _banner "Show Execution Time"
+    end_time=$(date +%s)
+    elapsed_time=$(( end_time - start_time ))
+    
+    ret=`date -d @${start_time}`
+    _echo "[Start Time ] ${ret}"
+    
+    ret=`date -d @${end_time}`
+    _echo "[End Time   ] ${ret}"    
+    
+    _echo "[Elapse Time] ${elapsed_time} seconds"
+}
+
 function _compression {
     _banner "Compression"
     
@@ -1812,6 +1831,7 @@ function _main {
     _show_bmc_sel_elist_detail
     _show_dmesg
     _additional_log_collection
+    _show_time
     _compression
 
     echo "#   done..."


### PR DESCRIPTION
tag onlpv1-r5.0.4 from ufi-onlpv1-dev branch
--------------------------------------------
01. [All][Common] ------------- No Update
02. [S9300-32D][r1.0.11]
     - [x] Add execution time in tech support script
03. [S9301-32DB][r1.0.6]
     - [x] Add execution time in tech support script
04. [S9310-32D][r1.0.8] ------- No Update
05. [S9500-22XST][r0.5] ------- No Update
06. [S9501-16SMT][r1.0.7] ----- No Update
07. [S9501-18SMT][r1.0.10]----- No Update
08. [S9501-28SMT][r1.0.12]----- No Update
09. [S9502-12SM][r1.0.3] ------ No Update
10. [S9502-16SMT][r1.0.3] ----- No Update
11. [S9510-28DC][r1.0.12]------ No Update
12. [S9510-30XC][r1.0.1] ------ No Update
13. [S9600-30DX][r1.0.0]------- No Update
14. [S9600-32X][r1.0.11] ------ No Update
15. [S9600-48X][r1.0.5] ------- No Update
16. [S9600-64X][r1.0.12] ------ No Update
17. [S9600-72XC][r1.0.15]
     - [x] Add execution time in tech support script
18. [S9700-23D][r4.2.21] ------ No Update
19. [S9700-53DX][r4.2.21] ----- No Update
20. [S9701-78DC][r1.0.10] ----- No Update
21. [S9701-82DC][r1.0.8]
     - [x] fix sysfs typo in qsfp control
     - [x] Add execution time in tech support script
22. [S9705-48D][r4.2.21] ------ No Update
23. [S9710-76D][r1.0.15] ------ No Update
24. [S9100-32X][r4.2.15] ------ No Update
25. [S9180-32X][r4.2.15] ------ No Update
26. [S9230-64X][r4.2.15] ------ No Update
27. [S9280-64X][r4.2.15] ------ No Update
28. [S9280-64X-4BWB][r4.2.15] - No Update